### PR TITLE
Add conditional PySide imports for Qt 6 compatibility

### DIFF
--- a/kshelpers.py
+++ b/kshelpers.py
@@ -14,8 +14,13 @@ import collections
 
 from binaryninja import log
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QTreeWidgetItem
+import binaryninjaui
+if "qt_major_version" in dir(binaryninjaui) and binaryninjaui.qt_major_version == 6:
+        from PySide6.QtCore import Qt
+        from PySide6.QtWidgets import QTreeWidgetItem
+else:
+        from PySide2.QtCore import Qt
+        from PySide2.QtWidgets import QTreeWidgetItem
 
 if sys.version_info[0] == 2:
 	import kaitaistruct

--- a/menu.py
+++ b/menu.py
@@ -6,9 +6,15 @@ import sys
 from binaryninjaui import StatusBarWidget, ContextMenuManager, Menu, UIActionHandler, UIAction
 
 # pyside stuff
-from PySide2.QtCore import Qt
-from PySide2.QtGui import QPalette
-from PySide2.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QLineEdit, QHeaderView, QLabel, QMenu, QHBoxLayout
+import binaryninjaui
+if "qt_major_version" in dir(binaryninjaui) and binaryninjaui.qt_major_version == 6:
+        from PySide6.QtCore import Qt
+        from PySide6.QtGui import QPalette
+        from PySide6.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QLineEdit, QHeaderView, QLabel, QMenu, QHBoxLayout
+else:
+        from PySide2.QtCore import Qt
+        from PySide2.QtGui import QPalette
+        from PySide2.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QLineEdit, QHeaderView, QLabel, QMenu, QHBoxLayout
 
 class KaitaiOptionsWidget(QLabel):
 	def __init__(self, parent):

--- a/view.py
+++ b/view.py
@@ -14,8 +14,14 @@ from binaryninja.settings import Settings
 from binaryninja import _binaryninjacore as core
 from binaryninjaui import View, ViewType, ViewFrame, UIContext, HexEditor, getMonospaceFont
 
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QLineEdit, QHeaderView, QSplitter
+
+import binaryninjaui
+if "qt_major_version" in dir(binaryninjaui) and binaryninjaui.qt_major_version == 6:
+        from PySide6.QtCore import Qt
+        from PySide6.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QLineEdit, QHeaderView, QSplitter
+else:
+        from PySide2.QtCore import Qt
+        from PySide2.QtWidgets import QScrollArea, QWidget, QVBoxLayout, QGroupBox, QTreeWidget, QTreeWidgetItem, QLineEdit, QHeaderView, QSplitter
 
 from . import menu
 


### PR DESCRIPTION
This should make this work on Qt 6. I took the suggestion from the Qt release notes to do the following:

```python
if "qt_major_version" in binaryninjaui and binaryninjaui.qt_major_version == 6:
```

However,  I had to add `dir(...)` to avoid getting a "type module is not iterable" error:
```python
if "qt_major_version" in dir(binaryninjaui) and binaryninjaui.qt_major_version == 6:
```