### PR TITLE
`len()` deprecation warning

### DIFF
--- a/plugin/view.py
+++ b/plugin/view.py
@@ -150,7 +150,7 @@ class KaitaiView(QScrollArea, View):
     def kaitaiParse(self, ksModuleName=None):
         #log_debug('INFO: kaitaiParse() with len(bv)=%d and bv.file.filename=%s' % (len(self.binaryView), self.binaryView.file.filename))
 
-        if len(self.binaryView) == 0:
+        if self.binaryView.length == 0:
             return
 
         kaitaiIO = kshelpers.KaitaiBinaryViewIO(self.binaryView)
@@ -207,7 +207,7 @@ class KaitaiView(QScrollArea, View):
         return result
 
     def getLength(self):
-        result = len(self.binaryView)
+        result = self.binaryView.length
         #log_debug('getLength() returning '+str(result))
         return result
 
@@ -365,7 +365,7 @@ class KaitaiViewType(ViewType):
             return 1
 
         # if we don't recognize it, return 0
-        ksModuleName = kshelpers.data_id(dataSample, len(binaryView))
+        ksModuleName = kshelpers.data_id(dataSample, binaryView.length)
         if not ksModuleName:
             return 1
 


### PR DESCRIPTION
Binary Ninja recently started to complain about `len()`:

> DeprecatedWarning: __len__ is deprecated. Use .length instead. Python disallows the length of an object to >= 0x8000000000000000. See https://bugs.python.org/issue21444.

This PR use the `length` property of the BinaryView object rather than the `len()` built-in.